### PR TITLE
Call SimplifyResult after fuse operation

### DIFF
--- a/figura/shapes.py
+++ b/figura/shapes.py
@@ -102,6 +102,7 @@ class Shape(object):
         if hasattr(shape, 'shape'):
             fuse = BRepAlgoAPI_Fuse(self.shape(), shape.shape())
             fuse.Build()
+            fuse.SimplifyResult()
             if not fuse.IsDone():
                 raise SystemExit("Objects were not fused")  # pragma: no cover
             return Shape.from_shape(fuse.Shape())


### PR DESCRIPTION
This provides the expected result (especially in 2D), i.e. edges are merged etc.
