### PR TITLE
Fixing problem with units when exporting multiple files

### DIFF
--- a/figura/io.py
+++ b/figura/io.py
@@ -3,7 +3,6 @@ from OCC.Core.STEPCAFControl import STEPCAFControl_Writer
 from OCC.Core.IFSelect import IFSelect_RetDone
 from OCC.Core.StlAPI import StlAPI_Writer
 from OCC.Core.BRepMesh import BRepMesh_IncrementalMesh
-from OCC.Core.Interface import Interface_Static
 from OCC.Core.XCAFDoc import (XCAFDoc_DocumentTool, XCAFDoc_ColorGen)
 from OCC.Core.TDocStd import TDocStd_Document
 from OCC.Core.TDataStd import TDataStd_Name
@@ -68,7 +67,6 @@ class STEPFile:
                 color_tool.SetColor(label, color, XCAFDoc_ColorGen)
 
         writer = STEPCAFControl_Writer()
-        Interface_Static.SetCVal("write.step.unit", figura.model.units.upper())
         writer.SetNameMode(True)
         writer.Transfer(doc, STEPControl_AsIs)
         writer.Write(self._file_name)

--- a/figura/model.py
+++ b/figura/model.py
@@ -1,3 +1,4 @@
+from OCC.Core.Interface import Interface_Static
 
 class Model:
 
@@ -13,5 +14,6 @@ class Model:
         # can be: "mm", "cm", "m"
         if value in ["mm", "cm", "m"]:
             self._units = value
+            Interface_Static.SetCVal("write.step.unit", value.upper())
         else:
             raise ValueError("Units can be either 'mm', 'cm' or 'm'.")


### PR DESCRIPTION
If units were set to something else than meter, and multiple files
were exported, the subsequent files had wrong dimension.
Now, unit are set in Model class when the setter is called.
