### PR TITLE
Adding export into multiple files

### DIFF
--- a/figura/__main__.py
+++ b/figura/__main__.py
@@ -70,6 +70,13 @@ def main():
                         get_file_ext(args.format))
                 save_file(shapes, args.output_file, args.output_dir,
                           file_format=args.format)
+            elif isinstance(shapes, dict):
+                for f, shs in shapes.items():
+                    out_file = f
+                    save_file(shs, out_file, args.output_dir,
+                              file_format=args.format)
+            else:
+                raise SystemExit("I don't know how to export shapes.")
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
User can say:
```
export = {
  'file1': [shapes_for_file1],
  'file2': [shapes_for_file2]
  ...
}
```
